### PR TITLE
Add Prisma namespace to types export

### DIFF
--- a/prisma/src/index.d.ts
+++ b/prisma/src/index.d.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+export { Prisma } from ".prisma/client";
 
 export interface Context {
   prisma: PrismaClient;

--- a/prisma/tsconfig.json
+++ b/prisma/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "declaration": true,
     "outDir": "./dist",
     "strict": true
   },


### PR DESCRIPTION
Thanks for putting this together, it was a huge help!

The Prisma namespace has helper types for query-building like 'UserInclude' and isn't currently exported.

I've added this export to the types file and removed "declaration": true from the ts config as index.d.ts is overwritten anyway in the prepare script.

You can now import the Prisma namespace in a similar way to the original prisma package, i.e:
`import { Prisma } from @MarcMogdanz/typed-prisma-package`
